### PR TITLE
Update 08-conditional-expressions.md

### DIFF
--- a/Day-2/08-conditional-expressions.md
+++ b/Day-2/08-conditional-expressions.md
@@ -62,7 +62,7 @@ resource "aws_security_group" "example" {
 
 ```
 
-In this example, the `locals` block uses a conditional expression to assign a value to the `subnet_cidr` local variable based on the value of the `environment` variable. If `environment` is set to `"production"`, it uses the `production_subnet_cidr` variable; otherwise, it uses the `development_subnet_cidr` variable.
+In this example, the `ingress` block uses a conditional expression to assign a value to the `subnet_cidr` local variable based on the value of the `environment` variable. If `environment` is set to `"production"`, it uses the `production_subnet_cidr` variable; otherwise, it uses the `development_subnet_cidr` variable.
 
 ## Conditional Resource Configuration 
 


### PR DESCRIPTION
`ingress` block was mistakenly written as `locals` block