### PR TITLE
Updated 09-builtin-functions.md

### DIFF
--- a/Day-2/09-builtin-functions.md
+++ b/Day-2/09-builtin-functions.md
@@ -50,17 +50,17 @@ output "list_length" {
 
 ```hcl
 variable "keys" {
-  type    = list
+  type    = list(string)
   default = ["name", "age"]
 }
 
 variable "values" {
-  type    = list
+  type    = list(any)
   default = ["Alice", 30]
 }
 
 output "my_map" {
-  value = map(var.keys, var.values) # Returns {"name" = "Alice", "age" = 30}
+  value = { for i, key in var.keys : key => var.values[i] } # Returns {"name" = "Alice", "age" = 30}
 }
 ```
 


### PR DESCRIPTION
Hi @iam-veeramalla ,

Solved Issue :

Error: Error in function call
│ 
│   on main.tf line 26, in output "my_map":
│   26:   value = map(var.keys, var.values) # Returns {"name" = "Alice", "age" = 30}
│     ├────────────────
│     │ while calling map(vals...)
│     │ var.keys is a list of dynamic
│     │ var.values is a list of dynamic
│ 
│ Call to function "map" failed: the "map" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... }) syntax to write a literal map.

Please review and approve it :)

Thanks