### PR TITLE
Enhance remote-exec provisioner for Flask setup

### DIFF
--- a/Day-5/main.tf
+++ b/Day-5/main.tf
@@ -92,10 +92,21 @@ resource "aws_instance" "server" {
     destination = "/home/ubuntu/app.py"  # Replace with the path on the remote instance
   }
 
-  provisioner "remote-exec" {
-    inline = [
-      "echo 'Hello from the remote instance'",
-      "sudo apt update -y",  # Update package lists (for ubuntu)
+ provisioner "remote-exec" {
+  inline = [
+    "sudo apt update -y",
+    "sudo apt install -y python3 python3-venv python3-pip",
+
+    # create virtual environment
+    "python3 -m venv /home/ubuntu/myenv",
+
+    # activate and install flask
+    "bash -c 'source /home/ubuntu/myenv/bin/activate && pip install flask'",
+
+    # run app in background properly
+    "nohup /home/ubuntu/myenv/bin/python /home/ubuntu/app.py > /home/ubuntu/app.log 2>&1 &"
+  ]
+}
       "sudo apt-get install -y python3-pip",  # Example package installation
       "cd /home/ubuntu",
       "sudo pip3 install flask",


### PR DESCRIPTION
Updated remote-exec provisioner to install Python, create a virtual environment, and run the Flask app in the background.